### PR TITLE
fix(popover): Focus case trigger topRight wrong value

### DIFF
--- a/stories/popover.stories.ts
+++ b/stories/popover.stories.ts
@@ -599,7 +599,6 @@ export class PopoverManualTriggerStoriesComponent {
                 mcPopoverTrigger="focus"
                 mcPopoverClass="popover-485 this-class-not-available"
                 mcPopoverHeader="Lorem ipsum"
-                mcPopoverTrigger="manual"
                 mcPopoverPlacement="topRight"
                 [mcPopoverContent]="customContent"
                 [mcPopoverFooter]="customFooter">


### PR DESCRIPTION
@Fost please take a look.
Fix for focus trigger story case.
Root cause - duplicated attribute mcTrigger on button with value 'manual'